### PR TITLE
Support full nextcloud coverage in debugger, and fix autoloading in composer file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
 			"request": "launch",
 			"port": 9003,
 			"pathMappings": {
-				"/var/www/html": "${workspaceFolder}/vendor/christophwurst/nextcloud/OCP",
+				"/var/www/html": "${workspaceFolder}/../nextcloud-server",
+				"/var/www/html/lib/public": "${workspaceFolder}/vendor/christophwurst/nextcloud/OCP",
 				"/var/www/html/custom_apps/adminly_core": "${workspaceFolder}/../adminly_core",
 				"/var/www/html/custom_apps/adminly_dashboard": "${workspaceFolder}/../adminly_dashboard"
 			}

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
 	"autoload-dev": {
 		"psr-4": {
 			"OCP\\": "vendor/christophwurst/nextcloud/OCP",
-			"OCA\\Adminly_Core\\": "../adminly_core",
-			"OCA\\Adminly_Dashboard\\": "../adminly_dashboard"
+			"OCA\\Adminly_Core\\": "../adminly_core/lib/",
+			"OCA\\Adminly_Dashboard\\": "../adminly_dashboard/lib/"
 		}
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -115,16 +115,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.2.9",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649"
+                "reference": "5d8e574bb0e69188786b8ef77d43341222a41a71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/a951f614bd64dcd26137bc9b7b2637ddcfc57649",
-                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649",
+                "url": "https://api.github.com/repos/composer/semver/zipball/5d8e574bb0e69188786b8ef77d43341222a41a71",
+                "reference": "5d8e574bb0e69188786b8ef77d43341222a41a71",
                 "shasum": ""
             },
             "require": {
@@ -187,7 +187,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-04T13:58:43+00:00"
+            "time": "2022-03-16T11:22:07+00:00"
         },
         {
             "name": "composer/xdebug-handler",


### PR DESCRIPTION
This adds the needed configuration so you can add a folder called nextcloud-server along side the adminly folders, and the debugger can reference does files for stuff that happens outside the public API.

This PR also fixes the file paths for the autoloading in the composer.json, as they were slightly off.