### PR TITLE
Remove php-cs extension and update php-cs config

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,5 +14,7 @@ $config
 	->notPath('l10n')
 	->notPath('src')
 	->notPath('vendor')
+	->notPath('node_modules')
+	->notPath('cypress')
 	->in(__DIR__);
 return $config;

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
 		"editorconfig.editorconfig",
-		"junstyle.php-cs-fixer",
 		"xdebug.php-debug",
 		"bmewburn.vscode-intelephense-client",
 		"esbenp.prettier-vscode"


### PR DESCRIPTION
The php-cs extension didn't seem to work as intended, so it shouldn't be a recommended extension. `make lint` can be used to run the through the linting.