### PR TITLE
Add cron to docker image for background jobs

### DIFF
--- a/adminly-dev.sh
+++ b/adminly-dev.sh
@@ -117,11 +117,12 @@ function setup ()
 	do
 		sleep 1
 	done
+	print "Enabling background jobs with cron"
+	docker-compose exec -u www-data nextcloud php occ background:cron
 	print "Disabling unneeded apps"
 	docker-compose exec -u www-data nextcloud php occ app:disable activity dashboard photos firstrunwizard recommendations
 	print "Install needed apps from Nextcloud app store"
 	docker-compose exec -u www-data nextcloud php occ app:install calendar
-	docker-compose exec -u www-data nextcloud php occ app:install side_menu
 	docker-compose exec -u www-data nextcloud php occ app:install appointments
 	print "Configuring Nextcloud"
 	# Configure user settings
@@ -133,8 +134,6 @@ function setup ()
 	docker-compose exec -u www-data nextcloud php occ theming:config url "https://adminly.org"
 	# Disable rich workspaces
 	docker-compose exec -u www-data nextcloud php occ config:app:set text workspace_available --value=0
-	# Configure side menu / custom menu
-	docker-compose exec -u www-data nextcloud php occ config:app:set side_menu always-displayed --value=1
 	# Enable Adminly apps
 	docker-compose exec -u www-data nextcloud php occ app:enable adminly_core adminly_dashboard
 	# Set Adminly Dashboard as the default app

--- a/docker/nextcloud/Dockerfile
+++ b/docker/nextcloud/Dockerfile
@@ -1,8 +1,33 @@
+FROM golang:1.18-bullseye as supercronic
+
+ENV SUPERCRONIC_VERSION v0.1.12
+
+# hadolint ignore=DL3003
+RUN set -ex; \
+    git clone --branch $SUPERCRONIC_VERSION https://github.com/aptible/supercronic; \
+    cd supercronic; \
+    go mod vendor; \
+    go install;
+
 FROM nextcloud:23
 
-RUN pecl install xdebug; \
+COPY --from=supercronic /go/bin/supercronic /usr/local/bin/supercronic
+
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        supervisor \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    chmod +x /usr/local/bin/supercronic; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /crontab; \
+    \
+	pecl install xdebug; \
     docker-php-ext-enable xdebug; \
     mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"; \
+    \
     { \
         echo "xdebug.mode = debug"; \
         echo "xdebug.start_with_request = yes"; \
@@ -15,3 +40,7 @@ RUN pecl install xdebug; \
     } > /usr/local/etc/php/conf.d/nextcloud.ini;
 
 ENV NEXTCLOUD_UPDATE=1
+
+COPY supervisord.conf /
+
+CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]

--- a/docker/nextcloud/supervisord.conf
+++ b/docker/nextcloud/supervisord.conf
@@ -1,0 +1,21 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/stdout
+pidfile=/tmp/supervisord.pid
+logfile_maxbytes=0                         ; maximum size of logfile before rotation                             ; number of backed up logfiles
+loglevel=info
+
+[program:php-fpm]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+command=apache2-foreground
+
+[program:cron]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+user=www-data
+command=supercronic /crontab


### PR DESCRIPTION
 Add cron to docker image for background jobs, configure cron in setup script, and remove side_menu from dev environment.

You just need to do a docker-compose build to rebuild the docker container and then run the setup command and the cronjob should run every 5 minutes.